### PR TITLE
Fix UnQLite URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![](http://media.charlesleifer.com/blog/photos/unqlite-python-logo.png)
 
-Fast Python bindings for [UnQLite](http://unqlite.symisc.net), a lightweight, embedded NoSQL database and JSON document store.
+Fast Python bindings for [UnQLite](http://unqlite.org/), a lightweight, embedded NoSQL database and JSON document store.
 
 ### Features
 


### PR DESCRIPTION
UnQLite was moved from unqlite.symisc.net to unqlite.org.