### PR TITLE
Fix link to engine.so

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Read the issue tracker for [this database](https://github.com/symisc/unqlite/issues/)** before considering using it. There
 are serious bugs and Symisc, UnQLite's maintainers, do not seem to be very
-forthright about these issues. I strongly urge you to use a different database. [Example issue](https://github.com/symisc/unqlite/issues/41). Check here for a comprehensive list of embedded databases: http://engine.so/
+forthright about these issues. I strongly urge you to use a different database. [Example issue](https://github.com/symisc/unqlite/issues/41). Check here for a comprehensive list of embedded databases: https://github.com/pmwkaa/engine.so
 
 ------------------------------------
 


### PR DESCRIPTION
With the old link I was hitting 404, a quick google search pointed me to https://github.com/pmwkaa/engine.so which seems to be the correct one.

Thanks for writing that warning, it saved me some time on my research! :+1: