### PR TITLE
Fix UnQLiteError.__init__ missing argument

### DIFF
--- a/unqlite.pyx
+++ b/unqlite.pyx
@@ -497,7 +497,7 @@ cdef class UnQLite(object):
             message = b'key not found'
         else:
             message = self._get_last_error()
-        return exc_class(message.decode('utf8'))
+        return exc_class(message.decode('utf8'), status)
 
     cdef _get_last_error(self):
         cdef int ret


### PR DESCRIPTION
Missing argument on line 500 causes `_build_exception_for_error` to fail with a `TypeError` for missing positional argument.

Before (In my case):
```py
  File "unqlite.pyx", line 453, in unqlite.UnQLite.exists
  File "unqlite.pyx", line 470, in unqlite.UnQLite.exists
  File "unqlite.pyx", line 500, in unqlite.UnQLite._build_exception_for_error
  File "unqlite.pyx", line 309, in unqlite.UnQLiteError.__init__
TypeError: __init__() takes exactly 3 positional arguments (2 given)
```
After (In my case):
```py
  File "unqlite.pyx", line 482, in unqlite.UnQLite.__contains__
  File "unqlite.pyx", line 470, in unqlite.UnQLite.exists
unqlite.UnQLiteError: Another process or thread hold the requested lock
Another process or thread have a reserved lock on this database
xOpen() method of the underlying KV engine 'hash' failed
```