### PR TITLE
pin cython version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,8 +39,8 @@ setup(
     author_email='',
     url='https://github.com/coleifer/unqlite-python',
     license='MIT',
-    install_requires=['Cython'],
-    setup_requires=['cython'],
+    install_requires=['Cython < 3.0.0'],
+    setup_requires=['cython < 3.0.0'],
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Environment :: Web Environment',


### PR DESCRIPTION
The recent release of Cython 3.0.0 introduced some breaking changes, and the uniqlite-python library no longer compiles correctly. This change pins the Cython dependency so as to avoid hitting this issue.