### PR TITLE
Add workflow for testing on multiple os, automate publish to pypi with compiled wheels

### DIFF
--- a/.github/workflows/build_publish.yaml
+++ b/.github/workflows/build_publish.yaml
@@ -1,0 +1,123 @@
+name: build_publish
+on:
+  workflow_dispatch
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  build_wheels:
+    name: Build ${{ matrix.python }}-${{ matrix.buildplat[1] }}
+    runs-on: ${{ matrix.buildplat[0] }}
+    strategy:
+      # Ensure that a wheel builder finishes even if another fails
+      fail-fast: false
+      matrix:
+        # Github Actions doesn't support pairing matrix values together, let's improvise
+        # https://github.com/github/feedback/discussions/7835#discussioncomment-1769026
+        buildplat:
+          - [ubuntu-latest, manylinux_x86_64]
+          - [ubuntu-latest, musllinux_x86_64]
+          - [macos-latest, macosx_x86_64]
+          - [windows-latest, win_amd64]
+          - [windows-2019, win32]
+        python: ["cp38", "cp39", "cp310", "cp311"]
+        # python: ["cp38"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+    
+      - name: Cache cibuild
+        id: cache-npm
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-cibuilds
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: /var/lib/docker/
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.16.5
+        env:
+          # TODO: Build Cython with the compile-all flag?
+          # Unfortunately, there is no way to modify cibuildwheel's build command
+          # so there is no way to pass this in directly.
+          # This would require modifying cython's setup.py to look for these flags
+          # in env vars.
+          CIBW_BEFORE_BUILD: "pip install Cython"
+          # CIBW_BEFORE_BUILD: "python setup.py build_ext --inplace"
+          CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
+          CIBW_ENVIRONMENT: CFLAGS='-O3 -g0 -mtune=generic -pipe -fPIC' LDFLAGS='-fPIC'          
+          CIBW_TEST_COMMAND: python {package}/tests.py
+
+     - name: check build
+        run: |
+          ls -l wheelhouse
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.python }}-${{ startsWith(matrix.buildplat[1], 'macosx') && 'macosx' || matrix.buildplat[1] }}
+          path: ./wheelhouse/*.whl
+
+  build_sdist:
+    name: Build sdist
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout quicksectx
+        uses: actions/checkout@v3
+      # Used to push the built wheels
+      - uses: actions/setup-python@v4
+        with:
+          # Build sdist on lowest supported Python
+          python-version: '3.8.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Build sdist
+        run: |
+          python setup.py sdist
+      - uses: actions/upload-artifact@v3
+        with:
+          name: sdist
+          path: ./dist/*.tar.gz
+
+  upload_pypi:
+    needs: [build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    # upload to PyPI on every tag starting with 'v'
+#    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    # alternatively, to publish when a GitHub Release is created, use the following rule:
+    # if: github.event_name == 'release' && github.event.action == 'published'
+    steps:
+      - uses: actions/setup-python@v4
+      - name: Install dependencies
+        run: |
+          pip install twine
+
+      - uses: actions/download-artifact@v3
+        with:
+          path: dist
+
+      - name: check downloaded
+        run: |
+          mv ./dist/**/* ./dist/
+          rm -rf dist/cp*
+          rm -rf dist/sdist
+          ls -R
+
+      - name: Build and publish
+        run: |
+          twine upload --skip-existing --verbose dist/*
+        env:
+#          TWINE_REPOSITORY: testpypi   # uncomment this line for test
+#         need to add Pypi token in secrets under the github repo's setting
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,12 +18,12 @@ jobs:
         # https://github.com/github/feedback/discussions/7835#discussioncomment-1769026
         buildplat:
           - [ubuntu-latest, manylinux_x86_64]
-          - [ubuntu-latest, musllinux_x86_64]
-          - [macos-latest, macosx_x86_64]
-          - [windows-latest, win_amd64]
-          - [windows-2019, win32]
-        python: ["cp38", "cp39", "cp310", "cp311"]
-        # python: ["cp38"]
+          # - [ubuntu-latest, musllinux_x86_64]
+          # - [macos-latest, macosx_x86_64]
+          # - [windows-latest, win_amd64]
+          # - [windows-2019, win32]
+        # python: ["cp38", "cp39", "cp310", "cp311"]
+        python: ["cp38"]
 
     steps:
       - name: Checkout
@@ -54,4 +54,4 @@ jobs:
           # CIBW_BEFORE_BUILD: "python setup.py build_ext --inplace"
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
           CIBW_ENVIRONMENT: CFLAGS='-O3 -g0 -mtune=generic -pipe -fPIC' LDFLAGS='-fPIC'          
-          CIBW_TEST_COMMAND: python tests.py
+          CIBW_TEST_COMMAND: ls && python tests.py

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,4 +1,4 @@
-name: test Builder
+name: test_build
 on:
   workflow_dispatch
 
@@ -8,36 +8,51 @@ concurrency:
 
 jobs:
   build_wheels:
-    name: Build ${{ matrix.python }}-${{ matrix.os }}-${{ matrix.cibw_archs }}
-    runs-on: ${{ matrix.cibw_archs || matrix.os }}
-    defaults:
-      run:
-        shell: bash
+    name: Build ${{ matrix.python }}-${{ matrix.buildplat[1] }}
+    runs-on: ${{ matrix.buildplat[0] }}
     strategy:
+      # Ensure that a wheel builder finishes even if another fails
       fail-fast: false
       matrix:
-        python: [cp38]
-        # python: [cp38, cp39, cp310, cp311]
-        os: [ubuntu-20.04, windows-latest, macos-11]
-        include:
-          - os: ubuntu-20.04
-          - os: windows-latest
-          - os: macos-11
+        # Github Actions doesn't support pairing matrix values together, let's improvise
+        # https://github.com/github/feedback/discussions/7835#discussioncomment-1769026
+        buildplat:
+          - [ubuntu-latest, manylinux_x86_64]
+          - [ubuntu-latest, musllinux_x86_64]
+          - [macos-latest, macosx_x86_64]
+          - [windows-latest, win_amd64]
+          - [windows-2019, win32]
+        python: ["cp38", "cp39", "cp310", "cp311"]
+        # python: ["cp38"]
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
     
-      - name: Build/Test/Package
+      - name: Cache cibuild
+        id: cache-npm
+        uses: actions/cache@v3
         env:
-          CIBW_ARCHS: ${{ matrix.cibw_archs }}
-          CIBW_BUILD: ${{matrix.python}}-*
-          CIBW_BUILD_VERBOSITY: 1
-          # containerized Linux builds require explicit CIBW_ENVIRONMENT
+          cache-name: cache-cibuilds
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: /var/lib/docker/
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.16.5
+        env:
+          # TODO: Build Cython with the compile-all flag?
+          # Unfortunately, there is no way to modify cibuildwheel's build command
+          # so there is no way to pass this in directly.
+          # This would require modifying cython's setup.py to look for these flags
+          # in env vars.
+          CIBW_BEFORE_BUILD: "pip install -r requirements.txt"
+          # CIBW_BEFORE_BUILD: "python setup.py build_ext --inplace"
+          CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
           CIBW_ENVIRONMENT: CFLAGS='-O3 -g0 -mtune=generic -pipe -fPIC' LDFLAGS='-fPIC'
           CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: pytest {package}/tests
-        run: |
-          pip install -U --user cibuildwheel
-          python -m cibuildwheel --platform auto --output-dir dist .
-
-

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,6 +1,10 @@
 name: test_build
 on:
-  workflow_dispatch
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -50,7 +50,7 @@ jobs:
           # so there is no way to pass this in directly.
           # This would require modifying cython's setup.py to look for these flags
           # in env vars.
-          CIBW_BEFORE_BUILD: "pip install -r requirements.txt"
+          CIBW_BEFORE_BUILD: "pip install Cython"
           # CIBW_BEFORE_BUILD: "python setup.py build_ext --inplace"
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
           CIBW_ENVIRONMENT: CFLAGS='-O3 -g0 -mtune=generic -pipe -fPIC' LDFLAGS='-fPIC'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,12 +18,12 @@ jobs:
         # https://github.com/github/feedback/discussions/7835#discussioncomment-1769026
         buildplat:
           - [ubuntu-latest, manylinux_x86_64]
-          # - [ubuntu-latest, musllinux_x86_64]
-          # - [macos-latest, macosx_x86_64]
-          # - [windows-latest, win_amd64]
-          # - [windows-2019, win32]
-        # python: ["cp38", "cp39", "cp310", "cp311"]
-        python: ["cp38"]
+          - [ubuntu-latest, musllinux_x86_64]
+          - [macos-latest, macosx_x86_64]
+          - [windows-latest, win_amd64]
+          - [windows-2019, win32]
+        python: ["cp38", "cp39", "cp310", "cp311"]
+        # python: ["cp38"]
 
     steps:
       - name: Checkout

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,12 +22,10 @@ jobs:
         include:
           - os: ubuntu-20.04
             cibw_archs: "x86_64"
-          - os: ubuntu-20.04
-            cibw_archs: "aarch64"
           - os: windows-latest
             cibw_archs: "auto"
           - os: macos-11
-            cibw_archs: "x86_64 universal2 arm64"
+            cibw_archs: "universal2"
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,21 +1,48 @@
-name: Tests
-on: [push]
+name: test Builder
+on:
+  workflow_dispatch
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
-  tests:
-    name: ${{ matrix.python-version }}
-    runs-on: ubuntu-latest
+  build_wheels:
+    name: Build ${{ matrix.python }}-${{ matrix.os }}-${{ matrix.cibw_archs }}
+    runs-on: ${{ matrix.cibw_archs || matrix.os }}
+    defaults:
+      run:
+        shell: bash
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, "3.10", "3.11"]
+        python: [cp38]
+        # python: [cp38, cp39, cp310, cp311]
+        os: [ubuntu-20.04, windows-latest, macos-11]
+        include:
+          - os: ubuntu-20.04
+            cibw_archs: "x86_64"
+          - os: ubuntu-20.04
+            cibw_archs: "aarch64"
+          - os: windows-latest
+            cibw_archs: "auto"
+          - os: macos-11
+            cibw_archs: "x86_64 universal2 arm64"
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: pip deps
+      - name: Checkout
+        uses: actions/checkout@v3
+    
+      - name: Build/Test/Package
+        env:
+          CIBW_ARCHS: ${{ matrix.cibw_archs }}
+          CIBW_BUILD: ${{matrix.python}}-*
+          CIBW_BUILD_VERBOSITY: 1
+          # containerized Linux builds require explicit CIBW_ENVIRONMENT
+          CIBW_ENVIRONMENT: CFLAGS='-O3 -g0 -mtune=generic -pipe -fPIC' LDFLAGS='-fPIC'
+          CIBW_TEST_REQUIRES: pytest
+          CIBW_TEST_COMMAND: pytest {package}/tests
         run: |
-          pip install cython
-          python setup.py build_ext -i
-      - name: runtests
-        run: python tests.py
+          pip install -U --user cibuildwheel
+          python -m cibuildwheel --platform auto --output-dir dist .
+
+

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -54,4 +54,4 @@ jobs:
           # CIBW_BEFORE_BUILD: "python setup.py build_ext --inplace"
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
           CIBW_ENVIRONMENT: CFLAGS='-O3 -g0 -mtune=generic -pipe -fPIC' LDFLAGS='-fPIC'          
-          CIBW_TEST_COMMAND: python /project/tests.py
+          CIBW_TEST_COMMAND: python {package}/tests.py

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,11 +21,8 @@ jobs:
         os: [ubuntu-20.04, windows-latest, macos-11]
         include:
           - os: ubuntu-20.04
-            cibw_archs: "x86_64"
           - os: windows-latest
-            cibw_archs: "auto"
           - os: macos-11
-            cibw_archs: "universal2"
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -54,4 +54,4 @@ jobs:
           # CIBW_BEFORE_BUILD: "python setup.py build_ext --inplace"
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
           CIBW_ENVIRONMENT: CFLAGS='-O3 -g0 -mtune=generic -pipe -fPIC' LDFLAGS='-fPIC'          
-          CIBW_TEST_COMMAND: python /project/test.py
+          CIBW_TEST_COMMAND: python /project/tests.py

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -53,6 +53,5 @@ jobs:
           CIBW_BEFORE_BUILD: "pip install Cython"
           # CIBW_BEFORE_BUILD: "python setup.py build_ext --inplace"
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
-          CIBW_ENVIRONMENT: CFLAGS='-O3 -g0 -mtune=generic -pipe -fPIC' LDFLAGS='-fPIC'
-          CIBW_TEST_REQUIRES: pytest
-          CIBW_TEST_COMMAND: pytest {package}/tests
+          CIBW_ENVIRONMENT: CFLAGS='-O3 -g0 -mtune=generic -pipe -fPIC' LDFLAGS='-fPIC'          
+          CIBW_TEST_COMMAND: python tests.py

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -54,4 +54,4 @@ jobs:
           # CIBW_BEFORE_BUILD: "python setup.py build_ext --inplace"
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
           CIBW_ENVIRONMENT: CFLAGS='-O3 -g0 -mtune=generic -pipe -fPIC' LDFLAGS='-fPIC'          
-          CIBW_TEST_COMMAND: pwd && ls -l  && ls -l /project
+          CIBW_TEST_COMMAND: python /project/test.py

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -54,4 +54,4 @@ jobs:
           # CIBW_BEFORE_BUILD: "python setup.py build_ext --inplace"
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
           CIBW_ENVIRONMENT: CFLAGS='-O3 -g0 -mtune=generic -pipe -fPIC' LDFLAGS='-fPIC'          
-          CIBW_TEST_COMMAND: pwd && ls -l
+          CIBW_TEST_COMMAND: pwd && ls -l  && ls -l /project

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -54,4 +54,4 @@ jobs:
           # CIBW_BEFORE_BUILD: "python setup.py build_ext --inplace"
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
           CIBW_ENVIRONMENT: CFLAGS='-O3 -g0 -mtune=generic -pipe -fPIC' LDFLAGS='-fPIC'          
-          CIBW_TEST_COMMAND: ls && python tests.py
+          CIBW_TEST_COMMAND: pwd && ls -l


### PR DESCRIPTION
You can use this workflow to publish to pypi with compiled wheels to avoid installation errors that often happen when the c/c++ compiler is not properly installed or configured in users' environment. We had a lot of trouble with it.