### PR TITLE
Fix null-byte starting keys such as 32-bit little-endian ints > 255

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -199,15 +199,8 @@ class TestKeyValueStorage(BaseTestCase):
                     raise e
             for k, v in byte_data:
                 w = db.fetch(k)
-                self.assertTrue(
-                    isinstance(w, bytes),
-                    msg=f"Fetch result for key {k} is not bytes: got {type(w)}"
-                )
-                self.assertEqual(
-                    w,
-                    v,
-                    msg=f"Mismatch for key {k}: expected {v} got {w}"
-                )
+                self.assertTrue(isinstance(w, bytes))
+                self.assertEqual(w, v)
 
 
 class TestTransaction(BaseTestCase):

--- a/tests.py
+++ b/tests.py
@@ -195,7 +195,7 @@ class TestKeyValueStorage(BaseTestCase):
                 try:
                     db.store(k, v)
                 except UnQLiteError as e:
-                    e.args = (f"{k!r}: {e}") + e.args[1:]
+                    e.args = f"{k!r}: {e}"
                     raise e
             for k, v in byte_data:
                 w = db.fetch(k)

--- a/tests.py
+++ b/tests.py
@@ -195,7 +195,7 @@ class TestKeyValueStorage(BaseTestCase):
                 try:
                     db.store(k, v)
                 except UnQLiteError as e:
-                    e.args = (f"{k!r}: {e}",) + e.args[1:]
+                    e.args = (f"{k!r}: {e}") + e.args[1:]
                     raise e
             for k, v in byte_data:
                 w = db.fetch(k)

--- a/tests.py
+++ b/tests.py
@@ -195,7 +195,7 @@ class TestKeyValueStorage(BaseTestCase):
                 try:
                     db.store(k, v)
                 except UnQLiteError as e:
-                    e.args = (f"Empty key {k!r}: {e}",) + e.args[1:]
+                    e.args = (f"{k!r}: {e}",) + e.args[1:]
                     raise e
             for k, v in byte_data:
                 w = db.fetch(k)

--- a/unqlite.pyx
+++ b/unqlite.pyx
@@ -410,7 +410,7 @@ cdef class UnQLite(object):
         self.check_call(unqlite_kv_store(
             self.database,
             <const char *>encoded_key,
-            len(encoded_key),
+            len(encoded_key), # to test the null-byte key prefix problem, revert this line to "-1,"
             <const char *>encoded_value,
             len(encoded_value)
         ))

--- a/unqlite.pyx
+++ b/unqlite.pyx
@@ -423,7 +423,7 @@ cdef class UnQLite(object):
         self.check_call(unqlite_kv_fetch(
             self.database,
             <const char *>encoded_key,
-            -1,
+            len(encoded_key),
             <void *>0,
             &buf_size))
 
@@ -432,7 +432,7 @@ cdef class UnQLite(object):
             self.check_call(unqlite_kv_fetch(
                 self.database,
                 <const char *>encoded_key,
-                -1,
+                len(encoded_key),
                 <void *>buf,
                 &buf_size))
             value = buf[:buf_size]
@@ -445,7 +445,7 @@ cdef class UnQLite(object):
         cdef bytes encoded_key = encode(key)
 
         self.check_call(unqlite_kv_delete(
-            self.database, <char *>encoded_key, -1))
+            self.database, <char *>encoded_key, len(encoded_key)))
 
     cpdef append(self, key, value):
         """Append to the value stored in the given key."""
@@ -455,7 +455,7 @@ cdef class UnQLite(object):
         self.check_call(unqlite_kv_append(
             self.database,
             <const char *>encoded_key,
-            -1,
+            len(encoded_key),
             <const char *>encoded_value,
             len(encoded_value)))
 
@@ -468,7 +468,7 @@ cdef class UnQLite(object):
         ret = unqlite_kv_fetch(
             self.database,
             <const char *>encoded_key,
-            -1,
+            len(encoded_key),
             <void *>0,
             &buf_size)
         if ret == UNQLITE_NOTFOUND:
@@ -731,7 +731,7 @@ cdef class Cursor(object):
         self.unqlite.check_call(unqlite_kv_cursor_seek(
             self.cursor,
             <char *>encoded_key,
-            -1,
+            len(encoded_key),
             flags))
 
     cpdef first(self):

--- a/unqlite.pyx
+++ b/unqlite.pyx
@@ -410,7 +410,7 @@ cdef class UnQLite(object):
         self.check_call(unqlite_kv_store(
             self.database,
             <const char *>encoded_key,
-            -1,
+            len(encoded_key),
             <const char *>encoded_value,
             len(encoded_value)))
 

--- a/unqlite.pyx
+++ b/unqlite.pyx
@@ -412,7 +412,8 @@ cdef class UnQLite(object):
             <const char *>encoded_key,
             len(encoded_key),
             <const char *>encoded_value,
-            len(encoded_value)))
+            len(encoded_value)
+        ))
 
     cpdef fetch(self, key):
         """Retrieve value at given key. Raises `KeyError` if key not found."""
@@ -425,7 +426,8 @@ cdef class UnQLite(object):
             <const char *>encoded_key,
             len(encoded_key),
             <void *>0,
-            &buf_size))
+            &buf_size
+        ))
 
         try:
             buf = <char *>malloc(buf_size)
@@ -434,7 +436,8 @@ cdef class UnQLite(object):
                 <const char *>encoded_key,
                 len(encoded_key),
                 <void *>buf,
-                &buf_size))
+                &buf_size
+            ))
             value = buf[:buf_size]
             return value
         finally:
@@ -445,7 +448,10 @@ cdef class UnQLite(object):
         cdef bytes encoded_key = encode(key)
 
         self.check_call(unqlite_kv_delete(
-            self.database, <char *>encoded_key, len(encoded_key)))
+            self.database,
+            <char *>encoded_key,
+            len(encoded_key)
+        ))
 
     cpdef append(self, key, value):
         """Append to the value stored in the given key."""
@@ -457,7 +463,8 @@ cdef class UnQLite(object):
             <const char *>encoded_key,
             len(encoded_key),
             <const char *>encoded_value,
-            len(encoded_value)))
+            len(encoded_value)
+        ))
 
     cpdef exists(self, key):
         cdef bytes encoded_key = encode(key)
@@ -470,7 +477,8 @@ cdef class UnQLite(object):
             <const char *>encoded_key,
             len(encoded_key),
             <void *>0,
-            &buf_size)
+            &buf_size
+        )
         if ret == UNQLITE_NOTFOUND:
             return False
         elif ret == UNQLITE_OK:
@@ -732,7 +740,8 @@ cdef class Cursor(object):
             self.cursor,
             <char *>encoded_key,
             len(encoded_key),
-            flags))
+            flags
+        ))
 
     cpdef first(self):
         """Set cursor to the first record in the database."""


### PR DESCRIPTION
### Keys beginning with `\0x00` fail with *Empty key* when in fact they are valid as far as unqlite is concerned.

*Given*
Attempts to store values using 32-bit int (4-byte) little-endian keys works for key values <= 255, but fails for key values > 255.

*Tests*
* Extend the byte-key test to include examples of these valid keys. Include enhanced error messaging to log which keys are failing and what error they produce.

*Resolution*
* Revise methods that use keys (eg store, delete etc) to instead of using `-1` for key length (auto-calculate length) to an explicit byte count - the encoded key length.

### Testing
Attempts to use the lib in production were resulting in little-endian keys working for some records and not others. After extensive logging it was discovered that ints <= 255 were fine, but above not. Because a 32-bit little-endian 256 is `\0x00\0x01\0x00\0x00` and `-1` (auto) was being used to specify key length, the key was being truncated _at the null_ hence reporting an `Empty key` error.

Here's an example with the enhanced test (and revised test reporting to fully describe the error), but before the fix was applied.

```bash
$ python tests.py
........................E.............
======================================================================
ERROR: test_byte_strings (__main__.TestKeyValueStorage)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/bevand10/Documents/evobytes/git/bevand10/unqlite-python/tests.py", line 199, in test_byte_strings
    raise e
  File "/home/bevand10/Documents/evobytes/git/bevand10/unqlite-python/tests.py", line 196, in test_byte_strings
    db.store(k, v)
  File "unqlite.pyx", line 405, in unqlite.UnQLite.store
    cpdef store(self, key, value):
  File "unqlite.pyx", line 410, in unqlite.UnQLite.store
    self.check_call(unqlite_kv_store(
  File "unqlite.pyx", line 507, in unqlite.UnQLite.check_call
    raise self._build_exception_for_error(result)
unqlite.UnQLiteError: b'\x00\x01\x00\x00': Empty key


----------------------------------------------------------------------
Ran 38 tests in 3.152s

FAILED (errors=1)
$
```

Fixes applied to `unqlite.pyx`.

_Remember (took me a while to figure this out) that when making changes to `uniqlite.pyx` and testing, one needs to execute `pip install .` to re-compile before the tests - run via `python tests.py` - will reveal the effect of your change._

With the fixes in place...

```bash
$ python tests.py
......................................
----------------------------------------------------------------------
Ran 38 tests in 1.186s

OK
```